### PR TITLE
Enable handles override

### DIFF
--- a/src/angular-gridster.js
+++ b/src/angular-gridster.js
@@ -2120,6 +2120,10 @@
                             return item.sizeY + ',' + item.sizeX + ',' + item.minSizeX + ',' + item.maxSizeX + ',' + item.minSizeY + ',' + item.maxSizeY;
                         }, sizeChanged);
 
+                        if(options.handles){
+                            item.gridster.resizable.handles = options.handles;
+                        }
+
                         var draggable = new GridsterDraggable($el, scope, gridster, item, options);
                         var resizable = new GridsterResizable($el, scope, gridster, item, options);
 


### PR DESCRIPTION
This enables to re-define the item-resizable handles by defining handles: [...] in widget.pos attribute
